### PR TITLE
dvbmediasink: redefine sync property of basesink

### DIFF
--- a/gstdvbaudiosink.c
+++ b/gstdvbaudiosink.c
@@ -87,6 +87,13 @@ GST_DEBUG_CATEGORY_STATIC(dvbaudiosink_debug);
 
 enum
 {
+	PROP_0,
+	PROP_SYNC,
+	PROP_LAST,
+};
+
+enum
+{
 	SIGNAL_GET_DECODER_TIME,
 	LAST_SIGNAL
 };
@@ -245,6 +252,8 @@ static GstCaps *gst_dvbaudiosink_get_caps(GstBaseSink *basesink, GstCaps *filter
 #endif
 static GstStateChangeReturn gst_dvbaudiosink_change_state(GstElement * element, GstStateChange transition);
 static gint64 gst_dvbaudiosink_get_decoder_time(GstDVBAudioSink *self);
+static void gst_dvbaudiosink_set_property (GObject * object, guint prop_id, const GValue * value, GParamSpec * pspec);
+static void gst_dvbaudiosink_get_property (GObject * object, guint prop_id, GValue * value, GParamSpec * pspec);
 
 /* initialize the plugin's class */
 static void gst_dvbaudiosink_class_init(GstDVBAudioSinkClass *self)
@@ -263,6 +272,12 @@ static void gst_dvbaudiosink_class_init(GstDVBAudioSinkClass *self)
 		"Outputs PES into a linuxtv dvb audio device",
 		"PLi team");
 #endif
+	gobject_class->set_property = gst_dvbaudiosink_set_property;
+	gobject_class->get_property = gst_dvbaudiosink_get_property;
+
+	g_object_class_install_property (gobject_class, PROP_SYNC,
+			g_param_spec_boolean ("sync", "Sync", "Sync on the clock", FALSE,
+					G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
 
 	gstbasesink_class->start = GST_DEBUG_FUNCPTR(gst_dvbaudiosink_start);
 	gstbasesink_class->stop = GST_DEBUG_FUNCPTR(gst_dvbaudiosink_stop);
@@ -316,6 +331,37 @@ static void gst_dvbaudiosink_init(GstDVBAudioSink *self)
 
 	gst_base_sink_set_sync(GST_BASE_SINK(self), FALSE);
 	gst_base_sink_set_async_enabled(GST_BASE_SINK(self), TRUE);
+}
+
+static void gst_dvbaudiosink_set_property (GObject * object, guint prop_id, const GValue * value, GParamSpec * pspec)
+{
+	GstDVBAudioSink *self = GST_DVBAUDIOSINK (object);
+
+	switch (prop_id)
+	{
+	/* sink should only work with sync turned off, ignore all attempts to change it */
+	case PROP_SYNC:
+		GST_DEBUG_OBJECT(self, "ignoring attempt to change 'sync' to '%d'", g_value_get_boolean(value));
+		break;
+	default:
+		G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+		break;
+	}
+}
+
+static void gst_dvbaudiosink_get_property (GObject * object, guint prop_id, GValue * value, GParamSpec * pspec)
+{
+	GstDVBAudioSink *self = GST_DVBAUDIOSINK (object);
+
+	switch (prop_id)
+	{
+	case PROP_SYNC:
+		g_value_set_boolean(value, gst_base_sink_get_sync(GST_BASE_SINK(object)));
+		break;
+	default:
+		G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+		break;
+	}
 }
 
 static gint64 gst_dvbaudiosink_get_decoder_time(GstDVBAudioSink *self)


### PR DESCRIPTION
Don't allow other elements to change sync property
Sinks should always operate with sync disabled.

http://forums.openpli.org/topic/29501-gstreamer-10/?view=findpost&p=505086
