### PR TITLE
Revert "dvbaudiosink: turn off async state changes"

### DIFF
--- a/gstdvbaudiosink.c
+++ b/gstdvbaudiosink.c
@@ -274,7 +274,7 @@ static void gst_dvbaudiosink_init(GstDVBAudioSink *self, GstDVBAudioSinkClass *g
 	self->timestamp = GST_CLOCK_TIME_NONE;
 
 	gst_base_sink_set_sync(GST_BASE_SINK(self), FALSE);
-	gst_base_sink_set_async_enabled(GST_BASE_SINK(self), FALSE);
+	gst_base_sink_set_async_enabled(GST_BASE_SINK(self), TRUE);
 }
 
 static gint64 gst_dvbaudiosink_get_decoder_time(GstDVBAudioSink *self)


### PR DESCRIPTION
This reverts commit 6f2f7bf8853344f3278ae9b0a14f8f4af77578f5.

This commit is ment only for gst-1.0 branch. It doesn't bring any
benefits when used with gstreamer-0.10.