### PR TITLE
dvbmediasink: accept h265 early NALU caps (workaround)

### DIFF
--- a/gstdvbvideosink.c
+++ b/gstdvbvideosink.c
@@ -196,6 +196,9 @@ GST_STATIC_PAD_TEMPLATE (
 #ifdef HAVE_H265
 	"video/x-h265, "
 		VIDEO_CAPS "; "
+	"video/x-h265, "
+		"parsed = (boolean) true, "
+		"alignment = (string) nal; "
 #endif
 #ifdef HAVE_H264
 	"video/x-h264, "


### PR DESCRIPTION
Following changes in 0853f31ce58ebe3a9cd7a642b03cdd9fe40fb715