### PR TITLE
Add parameter to control VP9 Super Frame Fix

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -247,6 +247,13 @@ if test "$have_vb9" = "yes"; then
 	AC_DEFINE([HAVE_VB9],[1],[Define to 1 for VB9 support])
 fi
 
+AC_ARG_WITH(vb9-sff,
+	AS_HELP_STRING([--with-vb9-ssf],[support VP9 super frame fix, yes or no]),
+	[have_vb9_sff=$withval],[have_vb9_sff=no])
+if test "$have_vb9_sff" = "yes"; then
+	AC_DEFINE([HAVE_VB9_SSF],[1],[Define to 1 for VB9 super frame fix])
+fi
+
 AC_ARG_WITH(spark,
 	AS_HELP_STRING([--with-spark],[support SPARK , yes or no]),
 	[have_spark=$withval],[have_spark=no])

--- a/configure.ac
+++ b/configure.ac
@@ -248,10 +248,10 @@ if test "$have_vb9" = "yes"; then
 fi
 
 AC_ARG_WITH(vb9-sff,
-	AS_HELP_STRING([--with-vb9-ssf],[support VP9 super frame fix, yes or no]),
+	AS_HELP_STRING([--with-vb9-sff],[support VP9 super frame fix, yes or no]),
 	[have_vb9_sff=$withval],[have_vb9_sff=no])
 if test "$have_vb9_sff" = "yes"; then
-	AC_DEFINE([HAVE_VB9_SSF],[1],[Define to 1 for VB9 super frame fix])
+	AC_DEFINE([HAVE_VB9_SFF],[1],[Define to 1 for VB9 super frame fix])
 fi
 
 AC_ARG_WITH(spark,

--- a/gstdvbvideosink.c
+++ b/gstdvbvideosink.c
@@ -1187,6 +1187,11 @@ static GstFlowReturn gst_dvbvideosink_render(GstBaseSink *sink, GstBuffer *buffe
 		payload_len += 4;
 	}
 
+#ifndef HAVE_VB9_SSF
+	pes_set_payload_size(payload_len, pes_header);
+	if (video_write(sink, self, self->pesheader_buffer, 0, pes_header_len) < 0) goto error;
+	if (video_write(sink, self, buffer, data - original_data, (data - original_data) + data_len) < 0) goto error;
+#else
 	if (self->codec_type == CT_VP9)
 	{
 		if (payload_len > 0x8008)
@@ -1286,6 +1291,7 @@ static GstFlowReturn gst_dvbvideosink_render(GstBaseSink *sink, GstBuffer *buffe
 #endif
 		if (video_write(sink, self, buffer, data - original_data, (data - original_data) + data_len) < 0) goto error;
 	}
+#endif /* HAVE_VB9_SSF */
 
 	if (GST_BUFFER_PTS_IS_VALID(buffer) || (self->use_dts && GST_BUFFER_DTS_IS_VALID(buffer)))
 	{

--- a/gstdvbvideosink.c
+++ b/gstdvbvideosink.c
@@ -1187,7 +1187,7 @@ static GstFlowReturn gst_dvbvideosink_render(GstBaseSink *sink, GstBuffer *buffe
 		payload_len += 4;
 	}
 
-#ifndef HAVE_VB9_SSF
+#ifndef HAVE_VB9_SFF
 	pes_set_payload_size(payload_len, pes_header);
 	if (video_write(sink, self, self->pesheader_buffer, 0, pes_header_len) < 0) goto error;
 	if (video_write(sink, self, buffer, data - original_data, (data - original_data) + data_len) < 0) goto error;
@@ -1291,7 +1291,7 @@ static GstFlowReturn gst_dvbvideosink_render(GstBaseSink *sink, GstBuffer *buffe
 #endif
 		if (video_write(sink, self, buffer, data - original_data, (data - original_data) + data_len) < 0) goto error;
 	}
-#endif /* HAVE_VB9_SSF */
+#endif /* HAVE_VB9_SFF */
 
 	if (GST_BUFFER_PTS_IS_VALID(buffer) || (self->use_dts && GST_BUFFER_DTS_IS_VALID(buffer)))
 	{


### PR DESCRIPTION
The super frame fix introduced on 4a708ad3e62f1494ba8ed3fdcdb323980d2bc835 is causing issues on several receivers.

It seems that super frame fix is not required for VU+, Edision, Hilicon boxes as seen here:
https://github.com/christophecvr/gstreamer1.0-plugin-multibox-dvbmediasink/blob/81090ee3e36fa60d6639a60f7fde385fea352210/gstdvbvideosink.c#L1284

Instead of introducing all the checks for models, introduce a single parameter --with-vp9-ssf.
Boxes require the super frame fix, they can use new parameter, to enable the optional fix.